### PR TITLE
Added numpad support

### DIFF
--- a/textscript/TextController.py
+++ b/textscript/TextController.py
@@ -32,6 +32,13 @@ class WordCatcher:
         # Creates instance wide keyboard variable
         self._keyboard = _keyboard
 
+        # Map virtual key codes for key codes outside the typical ASCII keyboard range
+        self._vk_map = {
+            110: '.',  # [Num .]
+        }
+        # Numpad support
+        self._vk_map.update({i: f'{i - 96}' for i in range(96, 106)})  # [Num 0] = 96, [Num 1] = 97, etc
+
         # Delimiter
         self._shortcut_delimiter = "#"
         self._command_delimiter = "!"
@@ -102,9 +109,20 @@ class WordCatcher:
         Converts KeyCode to string and strips quotations (into variable: keydata).
         """
 
-        # Converts KeyData to string, strips ' from result
-        self._keydata = str(self._key)
-        self._keydata = self._keydata.strip("'")
+        key = ""  # Default the returned key press to be a blank string
+
+        # Handle special virtual key code cases
+        if hasattr(self._key, 'vk'):
+            # Map the vk values
+            if self._key.vk in self._vk_map:
+                key = self._vk_map[self._key.vk]
+
+        # If no special cases need to be handled, then perform the default conversion
+        if key == "":
+            key = str(self._key)  # Converts KeyData to string
+
+        key = key.strip("'")  # Strips ' from around the returned character
+        self._keydata = key
 
     def _check_delimiter(self):
         """


### PR DESCRIPTION
# Description

Added support for the numpad. I created a dict in `WordCatcher.__init__` method called `self._vk_map` to map the pynput Key `vk` value to specific characters. For example virtual key code 97 maps to numpad `1`, and keycode 110 maps to numpad `.`.

Then in `WordCatcher._keycode_to_keydata` I added a mapping of the key code (`self._key.vk`) to that `self._vk_map` dict.

Fixes #
42 - Numerical text files not loading: https://github.com/GeorgeCiesinski/text-script/issues/42

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. Create a new textblock called `#test0123456789.txt`, and populate it with test text.
2. Run text-script, or `!reload` if it is already running.
3. Type `#test` and then use the numpad to type `0123456789` with the numpad.
4. Ensure that the shortcut is expanded to the full textblock.
5. Repeat step 3 and 4, but using the numbers at the top of the keyboard, to ensure regular numbers still work.

**Test Configuration**:
* OS: Windows 10
* IDE: N/A

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
